### PR TITLE
对mapper找不到的情况进行mapper的创建，以便增加对嵌套对象的默认处理

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Maven:
 <dependency>
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>easy-mapper</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 </dependency>
 ```
 Gradle:
 ```
-compile 'com.baidu.unbiz:easy-mapper:1.0.3'
+compile 'com.baidu.unbiz:easy-mapper:1.0.4'
 ```
 
 ### 1.2 Develop Java bean

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>easy-mapper</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.5-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>easy-mapper</name>
     <description>Easy mapper is a simple, light-weight tool for Java bean mapping</description>

--- a/src/test/java/com/baidu/unbiz/easymapper/EasyMapperTest.java
+++ b/src/test/java/com/baidu/unbiz/easymapper/EasyMapperTest.java
@@ -515,6 +515,50 @@ public class EasyMapperTest {
         assertThat(queryRequest.getOptList(), Matchers.is(pojoQueryRequest.getOptList()));
     }
 
+    @Test
+    public void testSourceToDest() {
+        Source s = getSource();
+
+        Dest d = MapperFactory.getCopyByRefMapper().mapClass(Source.class, Dest.class).register()
+                .map(s, Dest.class);
+
+        assertThat(d.getV().getV1(), Matchers.is(s.getV().getV1()));
+        assertThat(d.getV().getV2().getV1(), Matchers.is(s.getV().getV2().getV1()));
+        assertThat(d.getV().getV2().getV2(), Matchers.is(s.getV().getV2().getV2()));
+    }
+
+    @Test
+    public void testSource1ToDest1WithMapperPredefined() {
+        Source s = getSource();
+
+        MapperFactory.getCopyByRefMapper().mapClass(InnerSource.class, InnerDest.class).customMapping((a, b) -> {
+            b.setV1("hello");
+            b.setV2(null);
+        }).register();
+
+        Dest dest1 = MapperFactory.getCopyByRefMapper().mapClass(Source.class, Dest.class).register()
+                .map(s, Dest.class);
+
+        assertThat(dest1.getV().getV1(), Matchers.not(s.getV().getV1()));
+        assertThat(dest1.getV().getV2(), Matchers.not(s.getV().getV2()));
+        assertThat(dest1.getV().getV1(), Matchers.is("hello"));
+        assertThat(dest1.getV().getV2(), Matchers.nullValue());
+    }
+
+    private Source getSource() {
+        InnerInnerSource iis = new InnerInnerSource();
+        iis.setV1("v1");
+        iis.setV2("v2");
+
+        InnerSource is = new InnerSource();
+        is.setV1("v1");
+        is.setV2(iis);
+
+        Source s = new Source();
+        s.setV(is);
+        return s;
+    }
+
     @BeforeClass
     public static void init() {
 //        System.setProperty(SystemPropertyUtil.ENABLE_WRITE_SOURCE_FILE, "true");

--- a/src/test/java/com/baidu/unbiz/easymapper/vo/Dest.java
+++ b/src/test/java/com/baidu/unbiz/easymapper/vo/Dest.java
@@ -1,0 +1,14 @@
+package com.baidu.unbiz.easymapper.vo;
+
+public class Dest {
+
+    private InnerDest v;
+
+    public InnerDest getV() {
+        return v;
+    }
+
+    public void setV(InnerDest v) {
+        this.v = v;
+    }
+}

--- a/src/test/java/com/baidu/unbiz/easymapper/vo/InnerDest.java
+++ b/src/test/java/com/baidu/unbiz/easymapper/vo/InnerDest.java
@@ -1,0 +1,24 @@
+package com.baidu.unbiz.easymapper.vo;
+
+public class InnerDest {
+
+    private String v1;
+
+    private InnerInnerDest v2;
+
+    public String getV1() {
+        return v1;
+    }
+
+    public void setV1(String v1) {
+        this.v1 = v1;
+    }
+
+    public InnerInnerDest getV2() {
+        return v2;
+    }
+
+    public void setV2(InnerInnerDest v2) {
+        this.v2 = v2;
+    }
+}

--- a/src/test/java/com/baidu/unbiz/easymapper/vo/InnerInnerDest.java
+++ b/src/test/java/com/baidu/unbiz/easymapper/vo/InnerInnerDest.java
@@ -1,0 +1,22 @@
+package com.baidu.unbiz.easymapper.vo;
+
+public class InnerInnerDest {
+    private String v1;
+    private String v2;
+
+    public String getV1() {
+        return v1;
+    }
+
+    public void setV1(String v1) {
+        this.v1 = v1;
+    }
+
+    public String getV2() {
+        return v2;
+    }
+
+    public void setV2(String v2) {
+        this.v2 = v2;
+    }
+}

--- a/src/test/java/com/baidu/unbiz/easymapper/vo/InnerInnerSource.java
+++ b/src/test/java/com/baidu/unbiz/easymapper/vo/InnerInnerSource.java
@@ -1,0 +1,24 @@
+package com.baidu.unbiz.easymapper.vo;
+
+public class InnerInnerSource {
+
+    private String v1;
+
+    private String v2;
+
+    public String getV1() {
+        return v1;
+    }
+
+    public void setV1(String v1) {
+        this.v1 = v1;
+    }
+
+    public String getV2() {
+        return v2;
+    }
+
+    public void setV2(String v2) {
+        this.v2 = v2;
+    }
+}

--- a/src/test/java/com/baidu/unbiz/easymapper/vo/InnerSource.java
+++ b/src/test/java/com/baidu/unbiz/easymapper/vo/InnerSource.java
@@ -1,0 +1,23 @@
+package com.baidu.unbiz.easymapper.vo;
+
+public class InnerSource {
+
+    private String v1;
+    private InnerInnerSource v2;
+
+    public String getV1() {
+        return v1;
+    }
+
+    public void setV1(String v1) {
+        this.v1 = v1;
+    }
+
+    public InnerInnerSource getV2() {
+        return v2;
+    }
+
+    public void setV2(InnerInnerSource v2) {
+        this.v2 = v2;
+    }
+}

--- a/src/test/java/com/baidu/unbiz/easymapper/vo/Source.java
+++ b/src/test/java/com/baidu/unbiz/easymapper/vo/Source.java
@@ -1,0 +1,14 @@
+package com.baidu.unbiz.easymapper.vo;
+
+public class Source {
+
+    private InnerSource v;
+
+    public InnerSource getV() {
+        return v;
+    }
+
+    public void setV(InnerSource v) {
+        this.v = v;
+    }
+}


### PR DESCRIPTION
目前对于属性是对象的情况如果找不到对应的Mapper则直接报错，需要手工在外层增加对应类型的Mapper注册，这边在核心逻辑处提供一个默认的注册，如果找不到Mapper则自动进行对应类型的Mapper注册，省去很多业务层的手工注册代码。